### PR TITLE
Remove View Attendees button from browse events page

### DIFF
--- a/frontend/my-react-app/src/pages/EventsPage.tsx
+++ b/frontend/my-react-app/src/pages/EventsPage.tsx
@@ -480,6 +480,7 @@ function EventsPage() {
                   onClick={() => navigate(`/checkout/${event.eventID}`)}
                   variant="contained"
                   size="small"
+                  fullWidth
                 >
                   Buy ticket
                 </Button>
@@ -487,16 +488,10 @@ function EventsPage() {
                   onClick={() => handleAddToFavorites(event.eventID)}
                   variant={savedEventIds.has(event.eventID) ? "contained" : "outlined"}
                   size="small"
+                  fullWidth
                   disabled={savingEventId === event.eventID}
                 >
                   {savedEventIds.has(event.eventID) ? 'Saved' : 'Save event'}
-                </Button>
-                <Button
-                  onClick={() => navigate(`/event/${event.eventID}/registered-students`)}
-                  variant="outlined"
-                  size="small"
-                >
-                  View Attendees
                 </Button>
               </CardActions>
             </Card>


### PR DESCRIPTION
Removed the "View Attendees" button from event cards on the Browse Events page as it was non-functional and served no purpose for general users. Only "Buy Ticket" and "Save Event" buttons are now displayed, providing a cleaner UI focused on the primary user actions when browsing events.

closes #158 